### PR TITLE
Disallow external access to port 5901 (VNC)

### DIFF
--- a/operations_acl_rules.tf
+++ b/operations_acl_rules.tf
@@ -50,9 +50,10 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_https" {
   to_port        = 443
 }
 
-# Allow ingress from anywhere via ephemeral ports
+# Allow ingress from anywhere via lower ephemeral ports (1024-5900)
+# We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
-resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ephemeral_ports" {
+resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_1024_thru_5900" {
   network_acl_id = aws_network_acl.pca_operations.id
   egress         = false
   protocol       = "tcp"
@@ -60,6 +61,20 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ephemeral_
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 1024
+  to_port        = 5900
+}
+
+# Allow ingress from anywhere via upper ephemeral ports (5902-65535)
+# We do not want to allow everyone to hit VNC on port 5901
+# For: GoPhish fetches resources from https://fonts.googleapis.com
+resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_65535" {
+  network_acl_id = aws_network_acl.pca_operations.id
+  egress         = false
+  protocol       = "tcp"
+  rule_number    = "113"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 5902
   to_port        = 65535
 }
 

--- a/operations_acl_rules.tf
+++ b/operations_acl_rules.tf
@@ -50,7 +50,7 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_https" {
   to_port        = 443
 }
 
-# Allow ingress from anywhere via lower ephemeral ports (1024-5900)
+# Allow ingress from anywhere via ephemeral ports below 5901 (1024-5900)
 # We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
 resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_1024_thru_5900" {
@@ -64,7 +64,7 @@ resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_1024
   to_port        = 5900
 }
 
-# Allow ingress from anywhere via upper ephemeral ports (5902-65535)
+# Allow ingress from anywhere via ephemeral ports above 5901 (5902-65535)
 # We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
 resource "aws_network_acl_rule" "operations_ingress_from_anywhere_via_ports_5902_thru_65535" {

--- a/phishing_ops_security_group_rules.tf
+++ b/phishing_ops_security_group_rules.tf
@@ -42,14 +42,27 @@ resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_https
   to_port           = 443
 }
 
-# Allow ingress from anywhere via ephmeral ports
+# Allow ingress from anywhere via lower ephemeral ports (1024-5900)
+# We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
-resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_ephemeral_ports" {
+resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_ports_1024_thru_5900" {
   security_group_id = aws_security_group.pca_phishing_ops.id
   type              = "ingress"
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 1024
+  to_port           = 5900
+}
+
+# Allow ingress from anywhere via upper ephemeral ports (5902-65535)
+# We do not want to allow everyone to hit VNC on port 5901
+# For: GoPhish fetches resources from https://fonts.googleapis.com
+resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_ports_5902_thru_65535" {
+  security_group_id = aws_security_group.pca_phishing_ops.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 5902
   to_port           = 65535
 }
 

--- a/phishing_ops_security_group_rules.tf
+++ b/phishing_ops_security_group_rules.tf
@@ -42,7 +42,7 @@ resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_https
   to_port           = 443
 }
 
-# Allow ingress from anywhere via lower ephemeral ports (1024-5900)
+# Allow ingress from anywhere via ephemeral ports below 5901 (1024-5900)
 # We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
 resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_ports_1024_thru_5900" {
@@ -54,7 +54,7 @@ resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_via_ports
   to_port           = 5900
 }
 
-# Allow ingress from anywhere via upper ephemeral ports (5902-65535)
+# Allow ingress from anywhere via ephemeral ports above 5901 (5902-65535)
 # We do not want to allow everyone to hit VNC on port 5901
 # For: GoPhish fetches resources from https://fonts.googleapis.com
 resource "aws_security_group_rule" "phishing_ops_ingress_from_anywhere_ports_5902_thru_65535" {


### PR DESCRIPTION
Modify network ACL and security group rules to disallow external access to port 5901 (VNC).