### PR TITLE
Use real SSL certificate for Guacamole

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,55 @@
 [![Build Status](https://travis-ci.com/cisagov/pca-terraform.svg?branch=develop)](https://travis-ci.com/cisagov/pca-terraform)
 
 This project is used to create an operational Phishing Campaign Assessment
-(PCA) environment.
+(PCA) environment, containing the following instances:
+
+- [Guacamole](https://github.com/cisagov/guacamole-packer) clientless remote
+  desktop gateway
+- Phishing campaign assessment operating platform containing
+  [GoPhish, Postfix, and MailHog](https://github.com/cisagov/pca-gophish-composition-packer)
+
+## Pre-requisites ##
+
+- [Terraform](https://www.terraform.io/) installed on your system
+- An accessible AWS S3 bucket to store terraform state
+- An accessible AWS DynamoDB database to store the terraform state lock
+- Access to AWS AMIs for [Guacamole](https://github.com/cisagov/guacamole-packer)
+  and [GoPhish / Postfix / MailHog](https://github.com/cisagov/pca-gophish-composition-packer)
+- OpenSSL server certificate and private key for the Guacamole instance,
+  stored in an accessible AWS S3 bucket; this can be easily created via
+  [certboto-docker](https://github.com/cisagov/certboto-docker) or a similar
+  tool
+- A terraform [variables](variables.tf) file customized for your environment,
+  for example:
+
+  ```console
+  aws_region                    = "us-east-1"
+  aws_availability_zone         = "a"
+  cert_bucket_name              = "my-certificates"
+  dns_domain                    = "cisa.gov"
+  dns_role_arn                  = "arn:aws:iam::111111111111:role/ModifyPublicDNS"
+  dns_ttl                       = 60
+  guacamole_cert_read_role_arn  = "arn:aws:iam::111111111111:role/ReadCert-guacamole.example.cisa.gov"
+  guacamole_fqdn                = "guacamole.example.cisa.gov"
+  tags                          = {
+        Team        = "CISA - Example"
+        Application = "Phishing Campaign Assessment (PCA)"
+        Workspace   = "example"
+  }
+  trusted_ingress_networks_ipv4 = [ "192.168.1.0/24" ]
+  ```
+
+## Building the Terraform-based infrastructure ##
+
+```console
+# Initial setup only:
+terraform workspace create <your_workspace>
+terraform init
+
+# After initial setup:
+terraform workspace select <your_workspace>
+terraform apply -var-file=<your_tf_variables_file>
+```
 
 ## Contributing ##
 

--- a/desktop_gateway_security_group_rules.tf
+++ b/desktop_gateway_security_group_rules.tf
@@ -22,6 +22,17 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_gophish_via_ssh" {
   to_port           = 22
 }
 
+# Allow egress via https to anywhere
+# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
+resource "aws_security_group_rule" "desktop_gw_egress_to_anywhere_via_https" {
+  security_group_id = aws_security_group.pca_desktop_gateway.id
+  type              = "egress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+}
+
 # Allow ingress from trusted networks via port 8443 (nginx/guacamole web)
 # For: PCA team access to guacamole web client
 # TODO: Modify this access when VPN solution is implemented
@@ -44,4 +55,28 @@ resource "aws_security_group_rule" "desktop_gw_egress_to_gophish_via_vnc" {
   cidr_blocks       = ["${aws_instance.gophish.private_ip}/32"]
   from_port         = 5901
   to_port           = 5901
+}
+
+# Allow ingress from anywhere via ephemeral ports below 8443 (1024-8442)
+# We do not want to allow everyone to hit Guacamole on port 8443
+# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
+resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ports_1024_thru_8442" {
+  security_group_id = aws_security_group.pca_desktop_gateway.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 1024
+  to_port           = 8442
+}
+
+# Allow ingress from anywhere via ephemeral ports above 8443 (8444-65535)
+# We do not want to allow everyone to hit Guacamole on port 8443
+# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
+resource "aws_security_group_rule" "desktop_gw_ingress_from_anywhere_via_ports_8444_thru_65535" {
+  security_group_id = aws_security_group.pca_desktop_gateway.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 8444
+  to_port           = 65535
 }

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -1,0 +1,17 @@
+# cloud-init commands for configuring Guacamole instance
+
+data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    filename     = "install-certificates.yml"
+    content_type = "text/cloud-config"
+    content = templatefile(
+      "${path.module}/install-certificates.tpl.yml", {
+        cert_bucket_name   = var.cert_bucket_name
+        cert_read_role_arn = var.guacamole_cert_read_role_arn
+        server_fqdn        = var.guacamole_fqdn
+    })
+  }
+}

--- a/guacamole_ec2.tf
+++ b/guacamole_ec2.tf
@@ -23,10 +23,11 @@ data "aws_ami" "guacamole" {
 
 # The guacamole EC2 instance
 resource "aws_instance" "guacamole" {
-  ami               = data.aws_ami.guacamole.id
-  instance_type     = "t3.micro"
-  availability_zone = "${var.aws_region}${var.aws_availability_zone}"
-  subnet_id         = aws_subnet.pca_private.id
+  ami                  = data.aws_ami.guacamole.id
+  iam_instance_profile = aws_iam_instance_profile.guacamole.name
+  instance_type        = "t3.micro"
+  availability_zone    = "${var.aws_region}${var.aws_availability_zone}"
+  subnet_id            = aws_subnet.pca_private.id
   # TODO: Eventually get rid of public IP address for this instance
   associate_public_ip_address = true
 
@@ -35,6 +36,8 @@ resource "aws_instance" "guacamole" {
     volume_size           = 8
     delete_on_termination = true
   }
+
+  user_data_base64 = data.template_cloudinit_config.guacamole_cloud_init_tasks.rendered
 
   vpc_security_group_ids = [
     aws_security_group.pca_desktop_gateway.id,

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -1,0 +1,57 @@
+# Create the IAM instance profile for the Guacamole EC2 server instance
+
+# The instance profile to be used
+resource "aws_iam_instance_profile" "guacamole" {
+  name = "guacamole_instance_profile_${terraform.workspace}"
+  role = aws_iam_role.guacamole_instance_role.name
+}
+
+# The instance role
+resource "aws_iam_role" "guacamole_instance_role" {
+  name               = "guacamole_instance_role_${terraform.workspace}"
+  assume_role_policy = "${data.aws_iam_policy_document.guacamole_assume_role_policy_doc.json}"
+}
+
+# Attach policies to the instance role
+resource "aws_iam_role_policy" "guacamole_access_cert_policy" {
+  name   = "access_cert_policy"
+  role   = aws_iam_role.guacamole_instance_role.id
+  policy = "${data.aws_iam_policy_document.guacamole_read_cert_policy_doc.json}"
+}
+
+resource "aws_iam_role_policy" "guacamole_assume_delegated_role_policy" {
+  name   = "assume_delegated_role_policy"
+  role   = aws_iam_role.guacamole_instance_role.id
+  policy = "${data.aws_iam_policy_document.guacamole_assume_delegated_role_policy_doc.json}"
+}
+
+################################
+# Define the role policies below
+################################
+
+data "aws_iam_policy_document" "guacamole_assume_role_policy_doc" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "guacamole_read_cert_policy_doc" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${local.guacamole_cert_bucket_path_arn}"]
+    effect    = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "guacamole_assume_delegated_role_policy_doc" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["${var.guacamole_cert_read_role_arn}"]
+    effect    = "Allow"
+  }
+}

--- a/install-certificates.tpl.yml
+++ b/install-certificates.tpl.yml
@@ -1,0 +1,59 @@
+---
+write_files:
+  - path: /root/install-certificates.py
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/usr/bin/env python3
+
+      """Install certificates from AWS S3.
+
+      This file is a template.  It should be processed by terraform.
+      """
+
+      import boto3
+
+      # Inputs from terraform
+      CERT_BUCKET_NAME = "${cert_bucket_name}"
+      CERT_READ_ROLE_ARN = "${cert_read_role_arn}"
+      SERVER_FQDN = "${server_fqdn}"
+
+      # These files will be copied from the bucket
+      # and installed in the specified location.
+      INSTALLATION_MAP = {
+          "fullchain.pem": "/var/guacamole/nginx/ssl/self.cert",
+          "privkey.pem": "/var/guacamole/nginx/ssl/self-ssl.key",
+      }
+
+      # Create STS client
+      sts = boto3.client("sts")
+
+      # Assume the role that can read the certificate
+      stsresponse = sts.assume_role(
+          RoleArn=CERT_READ_ROLE_ARN, RoleSessionName="cert_installation"
+      )
+      newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+      newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+      newsession_token = stsresponse["Credentials"]["SessionToken"]
+
+      # Create a new client to access S3 using the temporary credentials
+      s3 = boto3.client(
+          "s3",
+          aws_access_key_id=newsession_id,
+          aws_secret_access_key=newsession_key,
+          aws_session_token=newsession_token,
+      )
+
+      # Copy each file from the bucket to the local file system
+      for src, dst in INSTALLATION_MAP.items():
+          obj = s3.get_object(
+            Bucket=CERT_BUCKET_NAME,
+            Key="live/{}/{}".format(SERVER_FQDN, src))
+          with open(dst, "wb") as f:
+              f.write(obj["Body"].read())
+
+runcmd:
+  - /root/install-certificates.py
+  - docker-compose -f /var/guacamole/docker-compose.yml restart
+  # Coming soon!
+  # - /bin/systemctl restart guacamole-composition.service

--- a/install-certificates.tpl.yml
+++ b/install-certificates.tpl.yml
@@ -52,8 +52,12 @@ write_files:
           with open(dst, "wb") as f:
               f.write(obj["Body"].read())
 
+# The guacamole-composition systemd service is guaranteed to start AFTER this
+# cloud-init script runs.  Therefore, we have to create
+# /var/guacamole/nginx/ssl/ before we put the certificate files in there.
+# Also, since the guacamole-composition service has not started up, there's
+# no need to restart it to use the newly-deployed certificate.
 runcmd:
+  # Ensure nginx ssl directory is present before we put the cert files there
+  - mkdir -p /var/guacamole/nginx/ssl/
   - /root/install-certificates.py
-  - docker-compose -f /var/guacamole/docker-compose.yml restart
-  # Coming soon!
-  # - /bin/systemctl restart guacamole-composition.service

--- a/locals.tf
+++ b/locals.tf
@@ -20,12 +20,4 @@ locals {
 
   # domain names to use for internal DNS
   pca_private_domain = "pca"
-
-  # zones to use for public DNS
-  pca_public_zone = "cyber.dhs.gov"
-
-  # subdomains to use in the public_zone.
-  # to create records directly in the public_zone set to ""
-  # otherwise it must end in a period
-  pca_public_subdomain = "pca.ncats."
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,9 @@
 locals {
+  guacamole_cert_bucket_path_arn = "${format("arn:aws:s3:::%s/live/%s/*",
+    var.cert_bucket_name,
+    var.guacamole_fqdn
+  )}"
+
   # This is a goofy but necessary way to determine if
   # terraform.workspace contains the substring "prod"
   production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -3,5 +3,14 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
+provider "aws" {
+  alias  = "dns"
+  region = "${var.aws_region}" # route53 is global, but still required by terraform
+  assume_role {
+    role_arn     = var.dns_role_arn
+    session_name = "terraform-pca-dns"
+  }
+}
+
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}

--- a/private_acl_rules.tf
+++ b/private_acl_rules.tf
@@ -15,7 +15,7 @@ resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_ssh" {
 }
 
 # Allow egress to anywhere via HTTPS
-# For: GoPhish fetches resources from https://fonts.googleapis.com
+# For: Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
 resource "aws_network_acl_rule" "private_egress_to_anywhere_via_https" {
   network_acl_id = aws_network_acl.pca_private.id
   egress         = true
@@ -67,20 +67,21 @@ resource "aws_network_acl_rule" "private_ingress_from_operations_via_ephemeral_p
   to_port        = 65535
 }
 
-# Allow ingress from anywhere via port 8443 (nginx/guacamole web)
+# Allow ingress from anywhere via ephemeral ports
 # Ingress is further restricted to only trusted networks via
 # the desktop gateway security group
 # For: PCA team access to guacamole web client
+#      Guacamole fetches its SSL certificate via boto3 (which uses HTTPS)
 # TODO: Modify this access when VPN solution is implemented
-resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_port_8443" {
+resource "aws_network_acl_rule" "private_ingress_from_anywhere_via_ephemeral_ports" {
   network_acl_id = aws_network_acl.pca_private.id
   egress         = false
   protocol       = "tcp"
   rule_number    = "110"
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
-  from_port      = 8443
-  to_port        = 8443
+  from_port      = 1024
+  to_port        = 65535
 }
 
 # Allow egress to operations subnet via VNC

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,14 @@
+# Find the DNS zone for the domain
+data "aws_route53_zone" "public_dns_zone" {
+  provider = aws.dns
+  name     = var.dns_domain
+}
+
+resource "aws_route53_record" "guacamole_A" {
+  provider = aws.dns
+  zone_id  = data.aws_route53_zone.public_dns_zone.zone_id
+  name     = var.guacamole_fqdn
+  type     = "A"
+  ttl      = var.dns_ttl
+  records  = ["${aws_instance.guacamole.public_ip}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,27 @@ variable "aws_availability_zone" {
   default     = "a"
 }
 
+variable "cert_bucket_name" {
+  type        = string
+  description = "The name of a bucket that stores certificates. (e.g. my-certs)"
+}
+
 
 variable "dns_role_arn" {
   type        = string
   description = "The ARN of the role that can modify route53 DNS. (e.g. arn:aws:iam::123456789abc:role/ModifyPublicDNS)"
 }
+
+variable "guacamole_cert_read_role_arn" {
+  type        = string
+  description = "A string containing the ARN of a role that can read the Guacamole instance certificate. (e.g. arn:aws:iam::123456789abc:role/ReadCerts)"
+}
+
+variable "guacamole_fqdn" {
+  type        = string
+  description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created"

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "aws_availability_zone" {
   default     = "a"
 }
 
+
+variable "dns_role_arn" {
+  type        = string
+  description = "The ARN of the role that can modify route53 DNS. (e.g. arn:aws:iam::123456789abc:role/ModifyPublicDNS)"
+}
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created"

--- a/variables.tf
+++ b/variables.tf
@@ -13,10 +13,18 @@ variable "cert_bucket_name" {
   description = "The name of a bucket that stores certificates. (e.g. my-certs)"
 }
 
+variable "dns_domain" {
+  description = "The domain to use for DNS (e.g. cyber.dhs.gov)"
+}
 
 variable "dns_role_arn" {
   type        = string
   description = "The ARN of the role that can modify route53 DNS. (e.g. arn:aws:iam::123456789abc:role/ModifyPublicDNS)"
+}
+
+variable "dns_ttl" {
+  description = "The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing."
+  default     = 60
 }
 
 variable "guacamole_cert_read_role_arn" {


### PR DESCRIPTION
This PR enables Guacamole to pull a proper SSL certificate from the specified S3 bucket.  It also opens up some additional ingress/egress ports that are needed for boto3 to talk to the S3 bucket.  Finally, it sets up a public DNS record for the Guacamole EC2 instance so that it will match the name on the certificate.