### PR TITLE
Automatically create Guacamole connection to GoPhish instance

### DIFF
--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -14,4 +14,22 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
         server_fqdn        = var.guacamole_fqdn
     })
   }
+
+  part {
+    filename     = "setup-guac-connection-sql.yml"
+    content_type = "text/cloud-config"
+    content = templatefile(
+      "${path.module}/setup-guac-connection-sql.tpl.yml", {
+        aws_region                               = var.aws_region
+        guac_connection_setup_filename           = var.guac_connection_setup_filename
+        guac_connection_setup_path               = var.guac_connection_setup_path
+        guac_gophish_connection_name             = var.guac_gophish_connection_name
+        pca_private_domain                       = local.pca_private_domain
+        ssm_gophish_vnc_read_role_arn            = var.ssm_gophish_vnc_read_role_arn
+        ssm_key_gophish_vnc_password             = var.ssm_key_gophish_vnc_password
+        ssm_key_gophish_vnc_user                 = var.ssm_key_gophish_vnc_username
+        ssm_key_gophish_vnc_user_private_ssh_key = var.ssm_key_gophish_vnc_user_private_ssh_key
+    })
+    merge_type = "list(append)+dict(recurse_array)+str()"
+  }
 }

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -50,8 +50,11 @@ data "aws_iam_policy_document" "guacamole_read_cert_policy_doc" {
 
 data "aws_iam_policy_document" "guacamole_assume_delegated_role_policy_doc" {
   statement {
-    actions   = ["sts:AssumeRole"]
-    resources = ["${var.guacamole_cert_read_role_arn}"]
-    effect    = "Allow"
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "${var.guacamole_cert_read_role_arn}",
+      "${var.ssm_gophish_vnc_read_role_arn}"
+    ]
+    effect = "Allow"
   }
 }

--- a/setup-guac-connection-sql.tpl.yml
+++ b/setup-guac-connection-sql.tpl.yml
@@ -1,0 +1,144 @@
+---
+# Ensure postgres init directory is present before we put any sql files there
+bootcmd:
+  - mkdir -p ${guac_connection_setup_path}
+
+# Write template file that will be processed by python (pystache)
+# Variables starting with <dollar-sign><left-curly-brace> will be replaced
+#  by terraform before cloud-init writes this file to the Guacamole instance
+# Variables starting with <left-curly-brace><left-curly-brace> will be
+#  replaced by pystache when we run the render_guac_connection_template_sql.py
+#  python script below
+write_files:
+  - path: "/root/guacamole_connection_template.sql"
+    permissions: "0644"
+    owner: root:root
+    content: |
+      --
+      -- Create connection for GoPhish instance
+      --
+
+      INSERT INTO guacamole_connection (
+        connection_name, protocol, max_connections, max_connections_per_user,
+        proxy_port, proxy_hostname, proxy_encryption_method)
+      VALUES (
+        '${guac_gophish_connection_name}', '{{ vnc_username }}', 10, 10, 4822,
+        'guacd', 'NONE');
+
+      --
+      -- Set up GoPhish connection details
+      --
+
+      INSERT INTO guacamole_connection_parameter (
+        connection_id, parameter_name, parameter_value)
+      SELECT connection_id, 'cursor', 'local'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT
+        connection_id, 'sftp-directory', '/home/{{ vnc_username }}/Documents'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'sftp-username', '{{ vnc_username }}'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'sftp-private-key', '{{ vnc_user_private_ssh_key }}'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'sftp-server-alive-interval', '60'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'sftp-root-directory', '/home/{{ vnc_username }}/'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'enable-sftp', 'true'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'color-depth', '24'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'hostname', 'gophish.${pca_private_domain}'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'password', '{{ vnc_password }}'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}'
+        UNION ALL
+      SELECT connection_id, 'port', '5901'
+      FROM guacamole_connection
+      WHERE connection_name = '${guac_gophish_connection_name}';
+  - path: "/root/render_guac_connection_template_sql.py"
+    permissions: "0755"
+    owner: root:root
+    content: |
+      #!/usr/bin/env python3
+
+      """Create Guacamole connection setup SQL.
+
+      This script fetches data from AWS SSM and then uses pystache to render a
+      SQL template using that SSM data.
+      """
+
+      import boto3
+      import pystache
+
+      SQL_TEMPLATE = "/root/guacamole_connection_template.sql"
+      SQL_OUTPUT_FILE = \
+        "${guac_connection_setup_path}/${guac_connection_setup_filename}"
+
+      # Inputs from terraform
+      SSM_READ_ROLE_ARN = "${ssm_gophish_vnc_read_role_arn}"
+      SSM_KEY_GOPHISH_VNC_PASSWORD = "${ssm_key_gophish_vnc_password}"
+      SSM_KEY_GOPHISH_VNC_USER = "${ssm_key_gophish_vnc_user}"
+      SSM_KEY_GOPHISH_VNC_USER_PRIVATE_SSH_KEY = \
+        "${ssm_key_gophish_vnc_user_private_ssh_key}"
+
+      # Create STS client
+      sts = boto3.client("sts")
+
+      # Assume the role that can read the SSM parameters
+      stsresponse = sts.assume_role(
+          RoleArn=SSM_READ_ROLE_ARN,
+          RoleSessionName="guacamole_connection_setup"
+      )
+      newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+      newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+      newsession_token = stsresponse["Credentials"]["SessionToken"]
+
+      # Create a new client to access SSM using the temporary credentials
+      ssm = boto3.client(
+          "ssm",
+          region_name="${aws_region}",
+          aws_access_key_id=newsession_id,
+          aws_secret_access_key=newsession_key,
+          aws_session_token=newsession_token,
+      )
+
+      # Fetch the required parameters from SSM
+      ssm_data = dict()
+      for ssm_key, param_name in (
+          (SSM_KEY_GOPHISH_VNC_USER, "vnc_username"),
+          (SSM_KEY_GOPHISH_VNC_PASSWORD, "vnc_password"),
+          (SSM_KEY_GOPHISH_VNC_USER_PRIVATE_SSH_KEY,
+           "vnc_user_private_ssh_key")):
+              ssm_parameter = ssm.get_parameter(
+                Name=ssm_key, WithDecryption=True)["Parameter"]
+              ssm_data[param_name] = ssm_parameter["Value"]
+
+      # Render template with SSM data and write output file
+      with open(SQL_TEMPLATE) as infile:
+          with open(SQL_OUTPUT_FILE, "w") as outfile:
+              outfile.write(pystache.render(infile.read(), ssm_data))
+
+# Run python script above to render SQL template, then remove template
+runcmd:
+  - /root/render_guac_connection_template_sql.py
+  - rm /root/guacamole_connection_template.sql

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,44 @@ variable "guacamole_cert_read_role_arn" {
   description = "A string containing the ARN of a role that can read the Guacamole instance certificate. (e.g. arn:aws:iam::123456789abc:role/ReadCerts)"
 }
 
+variable "guac_connection_setup_filename" {
+  type        = string
+  description = "The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections"
+  default     = "01_setup_guac_connections.sql"
+}
+
+variable "guac_connection_setup_path" {
+  type        = string
+  description = "The full path to the dbinit directory where <guac_connection_setup_filename> must be stored in order to work properly"
+  default     = "/var/guacamole/dbinit"
+}
+
+variable "guac_gophish_connection_name" {
+  type        = string
+  description = "The desired name of the Guacamole connection to the GoPhish instance"
+  default     = "GoPhish"
+}
+
+variable "ssm_gophish_vnc_read_role_arn" {
+  type        = string
+  description = "A string containing the ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"
+}
+
+variable "ssm_key_gophish_vnc_password" {
+  type        = string
+  description = "The AWS SSM parameter that contains the password needed to connect to the GoPhish instance via VNC (e.g. /vnc/password)"
+}
+
+variable "ssm_key_gophish_vnc_username" {
+  type        = string
+  description = "The AWS SSM parameter that contains the username of the VNC user on the GoPhish instance (e.g. /vnc/username)"
+}
+
+variable "ssm_key_gophish_vnc_user_private_ssh_key" {
+  type        = string
+  description = "The AWS SSM parameter that contains the private SSH key of the VNC user on the GoPhish instance (e.g. /vnc/ssh_private_key)"
+}
+
 variable "guacamole_fqdn" {
   type        = string
   description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "guacamole_cert_read_role_arn" {
 
 variable "guac_connection_setup_filename" {
   type        = string
-  description = "The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections"
+  description = "The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections.  NOTE: Postgres processes these files alphabetically, so it's important to name this file so it runs after the file that defines the Guacamole tables and users ('00_initdb.sql')."
   default     = "01_setup_guac_connections.sql"
 }
 


### PR DESCRIPTION
This PR uses cloud-init, terraform, python, boto3, and pystache to generate a file with the SQL commands that set up a Guacamole connection to the GoPhish instance.

Here's the process flow:
1. Terraform performs substitution in `setup-guac-connection-sql.tpl.yml` on variables (note that terraform variables look like this: `{$foo}`)
1. When the guacamole instance is deployed, cloud-init executes the commands in the rendered template:
   - If it doesn't already exist, create the directory where the Postgres Docker container will look to execute initialization SQL files the first time it is started up
   - Write a mustache template file (`guacamole_connection_template.sql`) with the SQL commands to create the Guacamole connection to the GoPhish instance (note that mustache variables look like this: `{{ bar }}`)
   - Write a python file (`render_guac_connection_template_sql.py`) that will fetch the necessary parameters from AWS SSM (via `boto3`), then render the mustache template (via `pystache`) with them and output the resulting file to the Postgres SQL initialization directory
   - Execute `render_guac_connection_template_sql.py`, then delete  `guacamole_connection_template.sql`
1. Since cloud-init is guaranteed to complete before our Docker composition starts up the Postgres and Guacamole containers (thanks to our [systemd unit file](https://github.com/cisagov/ansible-role-guacamole/blob/develop/files/guacamole-composition.service#L3)), our SQL initialization file will be present by the time the Postgres container starts, at which point Postgres will read the SQL files in the initialization directory and create the connection to the GoPhish instance.

NOTE: Files in the Postgres initialization directory are [processed alphabetically by filename](https://docs.docker.com/samples/library/postgres/#initialization-scripts), so it's important to name them appropriately.