### PR TITLE
Use cert-read-role-tf-module

### DIFF
--- a/cloud-init/write-guac-connection-sql-template.tpl.yml
+++ b/cloud-init/write-guac-connection-sql-template.tpl.yml
@@ -18,7 +18,7 @@ write_files:
         connection_name, protocol, max_connections, max_connections_per_user,
         proxy_port, proxy_hostname, proxy_encryption_method)
       VALUES (
-        '${guac_gophish_connection_name}', 'VNC', 10, 10, 4822,
+        '${guac_gophish_connection_name}', 'vnc', 10, 10, 4822,
         'guacd', 'NONE');
 
       --

--- a/guacamole_cloud_init.tf
+++ b/guacamole_cloud_init.tf
@@ -9,7 +9,7 @@ data "template_cloudinit_config" "guacamole_cloud_init_tasks" {
     content = templatefile(
       "${path.module}/cloud-init/install-certificates.py", {
         cert_bucket_name   = var.cert_bucket_name
-        cert_read_role_arn = var.guacamole_cert_read_role_arn
+        cert_read_role_arn = module.guacamole_certreadrole.arn
         server_fqdn        = var.guacamole_fqdn
     })
   }

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -1,3 +1,16 @@
+# Create a role that allows the instance to read its certs from S3.
+module "guacamole_certreadrole" {
+  source = "github.com/cisagov/cert-read-role-tf-module"
+
+  providers = {
+    aws = "aws.cert_read_role"
+  }
+
+  account_ids      = var.guac_cert_read_role_accounts_allowed
+  cert_bucket_name = var.cert_bucket_name
+  hostname         = var.guacamole_fqdn
+}
+
 # Create the IAM instance profile for the Guacamole EC2 server instance
 
 # The instance profile to be used
@@ -37,7 +50,7 @@ data "aws_iam_policy_document" "guacamole_assume_delegated_role_policy_doc" {
   statement {
     actions = ["sts:AssumeRole"]
     resources = [
-      "${var.guacamole_cert_read_role_arn}",
+      "${module.guacamole_certreadrole.arn}",
       "${var.ssm_gophish_vnc_read_role_arn}"
     ]
     effect = "Allow"

--- a/guacamole_iam.tf
+++ b/guacamole_iam.tf
@@ -12,13 +12,6 @@ resource "aws_iam_role" "guacamole_instance_role" {
   assume_role_policy = "${data.aws_iam_policy_document.guacamole_assume_role_policy_doc.json}"
 }
 
-# Attach policies to the instance role
-resource "aws_iam_role_policy" "guacamole_access_cert_policy" {
-  name   = "access_cert_policy"
-  role   = aws_iam_role.guacamole_instance_role.id
-  policy = "${data.aws_iam_policy_document.guacamole_read_cert_policy_doc.json}"
-}
-
 resource "aws_iam_role_policy" "guacamole_assume_delegated_role_policy" {
   name   = "assume_delegated_role_policy"
   role   = aws_iam_role.guacamole_instance_role.id
@@ -37,14 +30,6 @@ data "aws_iam_policy_document" "guacamole_assume_role_policy_doc" {
       identifiers = ["ec2.amazonaws.com"]
     }
     effect = "Allow"
-  }
-}
-
-data "aws_iam_policy_document" "guacamole_read_cert_policy_doc" {
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = ["${local.guacamole_cert_bucket_path_arn}"]
-    effect    = "Allow"
   }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,4 @@
 locals {
-  guacamole_cert_bucket_path_arn = "${format("arn:aws:s3:::%s/live/%s/*",
-    var.cert_bucket_name,
-    var.guacamole_fqdn
-  )}"
-
   # This is a goofy but necessary way to determine if
   # terraform.workspace contains the substring "prod"
   production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -12,5 +12,11 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region  = "${var.aws_region}"
+  profile = var.cert_read_role_profile
+  alias   = "cert_read_role"
+}
+
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,11 @@ variable "guac_gophish_connection_name" {
   default     = "GoPhish"
 }
 
+variable "guacamole_fqdn" {
+  type        = string
+  description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
+}
+
 variable "ssm_gophish_vnc_read_role_arn" {
   type        = string
   description = "A string containing the ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"
@@ -68,11 +73,6 @@ variable "ssm_key_gophish_vnc_username" {
 variable "ssm_key_gophish_vnc_user_private_ssh_key" {
   type        = string
   description = "The AWS SSM parameter that contains the private SSH key of the VNC user on the GoPhish instance (e.g. /vnc/ssh_private_key)"
-}
-
-variable "guacamole_fqdn" {
-  type        = string
-  description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable "cert_bucket_name" {
   description = "The name of a bucket that stores certificates. (e.g. my-certs)"
 }
 
+variable "cert_read_role_profile" {
+  type        = string
+  description = "The name of an AWS profile that has read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored (e.g. certreadrole-role)"
+}
+
 variable "dns_domain" {
   description = "The domain to use for DNS (e.g. cyber.dhs.gov)"
 }
@@ -27,9 +32,10 @@ variable "dns_ttl" {
   default     = 60
 }
 
-variable "guacamole_cert_read_role_arn" {
-  type        = string
-  description = "A string containing the ARN of a role that can read the Guacamole instance certificate. (e.g. arn:aws:iam::123456789abc:role/ReadCerts)"
+variable "guac_cert_read_role_accounts_allowed" {
+  type        = list(string)
+  description = "List of accounts allowed to access the role that can read certificates from an S3 bucket."
+  default     = []
 }
 
 variable "guac_connection_setup_filename" {


### PR DESCRIPTION
This PR switches us from using a hand-made role for pulling the Guacamole certificate from S3 to using the new [cert-read-role-tf-module](https://github.com/cisagov/cert-read-role-tf-module), which simplifies our terraform code a bit.

It also corrects a case-sensitivity bug that was introduced in https://github.com/cisagov/pca-terraform/commit/e012e2d67066cfa9028135dbb8b947394481c2af.