### PR TITLE
Support Multi-AWS-Account Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,23 @@ This project is used to create an operational Phishing Campaign Assessment
   aws_region                    = "us-east-1"
   aws_availability_zone         = "a"
   cert_bucket_name              = "my-certificates"
+  cert_read_role_arn            = "arn:aws:iam::123456789abc:role/CreateCertificateReadRoles"
   dns_domain                    = "cisa.gov"
-  dns_role_arn                  = "arn:aws:iam::111111111111:role/ModifyPublicDNS"
+  dns_role_arn                  = "arn:aws:iam::123456789abc:role/ModifyPublicDNS"
   dns_ttl                       = 60
-  guacamole_cert_read_role_arn  = "arn:aws:iam::111111111111:role/ReadCert-guacamole.example.cisa.gov"
   guacamole_fqdn                = "guacamole.example.cisa.gov"
+  guac_cert_read_role_accounts_allowed = ["123456789abc"]
+  local_ec2_profile             = terraform-pca-role
+  ssm_gophish_vnc_read_role_arn = "arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters"
+  ssm_key_gophish_vnc_password  = "/vnc/password"
+  ssm_key_gophish_vnc_username  = "/vnc/username"
+  ssm_key_gophish_vnc_user_private_ssh_key = "/vnc/ssh/rsa_private_key"
   tags                          = {
         Team        = "CISA - Example"
         Application = "Phishing Campaign Assessment (PCA)"
         Workspace   = "example"
   }
+  tf_role_arn                   = "arn:aws:iam::123456789abc:role/TerraformPCA"
   trusted_ingress_networks_ipv4 = [ "192.168.1.0/24" ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,76 @@ This project is used to create an operational Phishing Campaign Assessment
   trusted_ingress_networks_ipv4 = [ "192.168.1.0/24" ]
   ```
 
+## Terraform Variables ##
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-------:|:--------:|
+| aws_region | The AWS region to deploy into (e.g. us-east-1) | string | us-east-1 | no |
+| aws_availability_zone | The AWS availability zone to deploy into (e.g. a, b, c, etc.) | string | a | no |
+| cert_bucket_name | The name of a bucket that stores certificates. (e.g. my-certs) | string | | yes |
+| cert_read_role_arn | The ARN of the role that can create roles to have read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored. (e.g. arn:aws:iam::123456789abc:role/CreateCertificateReadRoles) | string | | yes |
+| create_pca_flow_logs | Whether or not to create flow logs for the PCA VPC. | bool | false | no |
+| dns_domain | The domain to use for DNS (e.g. cyber.dhs.gov) | string | | yes |
+| dns_role_arn | The ARN of the role that can modify route53 DNS. (e.g. arn:aws:iam::123456789abc:role/ModifyPublicDNS) | string | | yes |
+| dns_ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | number | 60 | no |
+| guac_cert_read_role_accounts_allowed | List of accounts allowed to access the role that can read certificates from an S3 bucket. | list(string) | `[]` | no |
+| guac_connection_setup_filename | The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections.  NOTE: Postgres processes these files alphabetically, so it's important to name this file so it runs after the file that defines the Guacamole tables and users ('00_initdb.sql'). | string | 01_setup_guac_connections.sql | no |
+| guac_connection_setup_path | The desired name of the Guacamole connection to the GoPhish instance | string | GoPhish | no |
+| guacamole_fqdn | The fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov) | string | | yes |
+| local_ec2_profile | The name of a local AWS profile (e.g. in your ~/.aws/credentials) that has permission to terminate and check the status of the PCA EC2 instances. (e.g. terraform-pca-role) | string | | yes |
+| ssm_gophish_vnc_read_role_arn | The ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters) | string | | yes |
+| ssm_key_gophish_vnc_password | The AWS SSM parameter that contains the password needed to connect to the GoPhish instance via VNC (e.g. /vnc/password) | string | | yes |
+| ssm_key_gophish_vnc_username | The AWS SSM parameter that contains the username of the VNC user on the GoPhish instance (e.g. /vnc/username) | string | | yes |
+| ssm_key_gophish_vnc_user_private_ssh_key | The AWS SSM parameter that contains the private SSH key of the VNC user on the GoPhish instance (e.g. /vnc/ssh_private_key) | string | | yes |
+| tf_role_arn | The ARN of the role that can terraform resources. (e.g. arn:aws:iam::123456789abc:role/TerraformPCA) | string | | yes |
+| tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
+| trusted_ingress_networks_ipv4 | IPv4 CIDR blocks from which to allow ingress to the desktop gateway | list(string) | `["0.0.0.0/0"]` | no |
+| trusted_ingress_networks_ipv6 | IPv6 CIDR blocks from which to allow ingress to the desktop gateway | list(string) | `["::/0"]` | no |
+
+## Setting up the Terraform AWS S3 backend ##
+
+Modify the following parameters in [terraform.tf](terraform.tf) to match
+your environment:
+
+- `bucket`: The name of your S3 bucket for storing terraform state
+- `dynamodb_table`: The name of your DynamoDB table for storing the terraform
+  state lock
+- `profile`: The name of a local AWS profile (e.g. in `~/.aws/credentials`)
+  that has the permissions below for the bucket and table above:
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::your-terraform-state-bucket"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::your-terraform-state-bucket/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem"
+            ],
+            "Resource": "arn:aws:dynamodb:*:123456789abc:table/your-dynamodb-table"
+        }
+    ]
+  }
+  ```
+
+NOTE: The bucket and table above must be created prior to running
+`terraform init` in the next step.
+
 ## Building the Terraform-based infrastructure ##
 
 ```console

--- a/gophish_ec2.tf
+++ b/gophish_ec2.tf
@@ -93,14 +93,14 @@ resource "aws_volume_attachment" "gophish_data_attachment" {
   # 'terraform apply' to re-create it.
   provisioner "local-exec" {
     when       = destroy
-    command    = "aws --region=${var.aws_region} ec2 terminate-instances --instance-ids ${aws_instance.gophish.id}"
+    command    = "aws --region=${var.aws_region} --profile=${var.local_ec2_profile} ec2 terminate-instances --instance-ids ${aws_instance.gophish.id}"
     on_failure = continue
   }
 
   # Wait until instance is terminated before continuing on
   provisioner "local-exec" {
     when    = destroy
-    command = "aws --region=${var.aws_region} ec2 wait instance-terminated --instance-ids ${aws_instance.gophish.id}"
+    command = "aws --region=${var.aws_region} --profile=${var.local_ec2_profile} ec2 wait instance-terminated --instance-ids ${aws_instance.gophish.id}"
   }
 
   skip_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,16 @@
 # Configure AWS
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
+  # Our primary provider uses our terraform role
+  assume_role {
+    role_arn     = var.tf_role_arn
+    session_name = "terraform-pca"
+  }
 }
 
 provider "aws" {
   alias  = "dns"
-  region = "${var.aws_region}" # route53 is global, but still required by terraform
+  region = var.aws_region # route53 is global, but still required by terraform
   assume_role {
     role_arn     = var.dns_role_arn
     session_name = "terraform-pca-dns"
@@ -13,9 +18,12 @@ provider "aws" {
 }
 
 provider "aws" {
-  region  = "${var.aws_region}"
-  profile = var.cert_read_role_profile
-  alias   = "cert_read_role"
+  alias  = "cert_read_role"
+  region = var.aws_region
+  assume_role {
+    role_arn     = var.cert_read_role_arn
+    session_name = "terraform-pca-cert"
+  }
 }
 
 # The AWS account ID being used

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,10 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "playground-terraform-state-storage"
+    bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    region         = "us-east-1"
+    encrypt        = true
     key            = "pca-terraform/terraform.tfstate"
+    profile        = "terraform-role" # This profile must be defined in your AWS credentials file
+    region         = "us-east-1"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "cert_read_role_arn" {
   description = "The ARN of the role that can create roles to have read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored. (e.g. arn:aws:iam::123456789abc:role/CreateCertificateReadRoles)"
 }
 
+variable "create_pca_flow_logs" {
+  type        = bool
+  description = "Whether or not to create flow logs for the PCA VPC."
+  default     = false
+}
+
 variable "dns_domain" {
   description = "The domain to use for DNS (e.g. cyber.dhs.gov)"
 }
@@ -109,10 +115,4 @@ variable "trusted_ingress_networks_ipv6" {
   type        = list(string)
   description = "IPv6 CIDR blocks from which to allow ingress to the desktop gateway"
   default     = ["::/0"]
-}
-
-variable "create_pca_flow_logs" {
-  type        = bool
-  description = "Whether or not to create flow logs for the PCA VPC."
-  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,9 +13,9 @@ variable "cert_bucket_name" {
   description = "The name of a bucket that stores certificates. (e.g. my-certs)"
 }
 
-variable "cert_read_role_profile" {
+variable "cert_read_role_arn" {
   type        = string
-  description = "The name of an AWS profile that has read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored (e.g. certreadrole-role)"
+  description = "The ARN of the role that can create roles to have read access to the S3 bucket ('cert_bucket_name' above) where certificates are stored. (e.g. arn:aws:iam::123456789abc:role/CreateCertificateReadRoles)"
 }
 
 variable "dns_domain" {
@@ -79,6 +79,11 @@ variable "ssm_key_gophish_vnc_username" {
 variable "ssm_key_gophish_vnc_user_private_ssh_key" {
   type        = string
   description = "The AWS SSM parameter that contains the private SSH key of the VNC user on the GoPhish instance (e.g. /vnc/ssh_private_key)"
+}
+
+variable "tf_role_arn" {
+  type        = string
+  description = "The ARN of the role that can terraform resources. (e.g. arn:aws:iam::123456789abc:role/TerraformPCA)"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,11 @@ variable "guacamole_fqdn" {
   description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
 }
 
+variable "local_ec2_profile" {
+  type        = string
+  description = "The name of a local AWS profile (e.g. in your ~/.aws/credentials) that has permission to terminate and check the status of the PCA EC2 instances. (e.g. terraform-pca-role)"
+}
+
 variable "ssm_gophish_vnc_read_role_arn" {
   type        = string
   description = "A string containing the ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "guac_gophish_connection_name" {
 
 variable "guacamole_fqdn" {
   type        = string
-  description = "A string containing the fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
+  description = "The fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
 }
 
 variable "local_ec2_profile" {
@@ -68,7 +68,7 @@ variable "local_ec2_profile" {
 
 variable "ssm_gophish_vnc_read_role_arn" {
   type        = string
-  description = "A string containing the ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"
+  description = "The ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"
 }
 
 variable "ssm_key_gophish_vnc_password" {


### PR DESCRIPTION
This PR includes everything that was needed to go from a single (AWS) account setup, to our more modern multi-account setup.

I also took some time to enhance and clean up the README.