### PR TITLE
Remove gophish local-exec provisioners

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This project is used to create an operational Phishing Campaign Assessment
   dns_ttl                       = 60
   guacamole_fqdn                = "guacamole.example.cisa.gov"
   guac_cert_read_role_accounts_allowed = ["123456789abc"]
-  local_ec2_profile             = terraform-pca-role
   ssm_gophish_vnc_read_role_arn = "arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters"
   ssm_key_gophish_vnc_password  = "/vnc/password"
   ssm_key_gophish_vnc_username  = "/vnc/username"
@@ -64,7 +63,6 @@ This project is used to create an operational Phishing Campaign Assessment
 | guac_connection_setup_filename | The name of the file to create on the Guacamole instance containing SQL instructions to populate any desired Guacamole connections.  NOTE: Postgres processes these files alphabetically, so it's important to name this file so it runs after the file that defines the Guacamole tables and users ('00_initdb.sql'). | string | 01_setup_guac_connections.sql | no |
 | guac_connection_setup_path | The desired name of the Guacamole connection to the GoPhish instance | string | GoPhish | no |
 | guacamole_fqdn | The fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov) | string | | yes |
-| local_ec2_profile | The name of a local AWS profile (e.g. in your ~/.aws/credentials) that has permission to terminate and check the status of the PCA EC2 instances. (e.g. terraform-pca-role) | string | | yes |
 | ssm_gophish_vnc_read_role_arn | The ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters) | string | | yes |
 | ssm_key_gophish_vnc_password | The AWS SSM parameter that contains the password needed to connect to the GoPhish instance via VNC (e.g. /vnc/password) | string | | yes |
 | ssm_key_gophish_vnc_username | The AWS SSM parameter that contains the username of the VNC user on the GoPhish instance (e.g. /vnc/username) | string | | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -67,11 +67,6 @@ variable "guacamole_fqdn" {
   description = "The fully-qualified domain name of the Guacamole instance; it must match the name on the certificate that resides in <cert_bucket_name>. (e.g. guacamole.example.cisa.gov)"
 }
 
-variable "local_ec2_profile" {
-  type        = string
-  description = "The name of a local AWS profile (e.g. in your ~/.aws/credentials) that has permission to terminate and check the status of the PCA EC2 instances. (e.g. terraform-pca-role)"
-}
-
 variable "ssm_gophish_vnc_read_role_arn" {
   type        = string
   description = "The ARN of a role that can get the SSM parameters for the VNC username, password, and private SSH key used on the GoPhish instance. (e.g. arn:aws:iam::123456789abc:role/ReadGoPhishVNCSSMParameters)"


### PR DESCRIPTION
Back when we first started developing [cyhy_amis](https://github.com/cisagov/cyhy_amis), we had to work around a terraform issue that was causing us some grief.  Essentially, whenever terraform tried to replace an EC2 instance that had a persistent EBS volume mounted, it would fail because terraform couldn't destroy the volume attachment of an active instance.  The workaround we came up with was to use a local-exec provisioner to terminate the EC2 instance before proceeding (see https://github.com/cisagov/cyhy_amis/commit/a9360551c4dbc1e540cb9c5b2d619262ba0869ed and 
https://github.com/cisagov/cyhy_amis/commit/066a90f754e12b9cdc0360a65f46095acd49f88c).

Recently, I decided to test if this workaround was still needed, after a year of releases from both Terraform and AWS.  Happily, it looks like our old workaround is no longer needed, at least for this repo.  Without these `local-exec` provisioners, I was able to do a `terraform apply` that successfully destroyed an existing gophish EC2 instance and created a fresh one.  I was also able to do a `terraform destroy` that successfully destroyed an existing gophish EC2 instance.

@mcdonnnj if you are interested and have some cycles, it might be worthwhile to test if we can also remove this workaround from the [cyhy_amis](https://github.com/cisagov/cyhy_amis) instances, as it would improve our quality-of-life during deployments.